### PR TITLE
Ensure users provide their own passwords.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Before building Device Manager, the following steps are required:
   ```
 - Docker 20.10.18 (minimum version) installed,
 - Certificates delivered or generated and placed into (project root)/build/certs (create this folder if necessary) (scripts for generation can be found [here](https://github.com/ODIM-Project/ODIM/tree/main/build/cert_generator)),
-- Config changes to fit your needs(insert your own password in configs below - use SHA3-512 hash and encode it with base64):
+- Config changes to fit your needs(insert your own passwords in configs below (passwords can be different between configs) - use SHA3-512 hash and encode it with base64):
   - **Device Manager**
     - (project root)/svc-device-manager/config/config.yml
       - Basic Authentication -> Password

--- a/README.md
+++ b/README.md
@@ -42,13 +42,16 @@ Before building Device Manager, the following steps are required:
   ```
 - Docker 20.10.18 (minimum version) installed,
 - Certificates delivered or generated and placed into (project root)/build/certs (create this folder if necessary) (scripts for generation can be found [here](https://github.com/ODIM-Project/ODIM/tree/main/build/cert_generator)),
-- Config changes to fit your needs:
+- Config changes to fit your needs(insert your own password in configs below - use SHA3-512 hash and encode it with base64):
   - **Device Manager**
     - (project root)/svc-device-manager/config/config.yml
+      - Basic Authentication -> Password
   - **ODIM services**
     - (project root)/lib-utilities/config/odimra_config.json
   - **Redis**
     - (project root)/build/redis/redis.conf
+    - (project root)/build/redis/createSchema.sh
+      - Line 4 -> "Password":"your_password_here"
   - **Etcd**
     - (project root)/build/etcd/etcd.yml
 
@@ -65,7 +68,7 @@ Once that make is complete, the Redfish interface will be available at 127.0.0.1
 After installation, you have to register Device Manager to ODIM. This is done by using Aggregation Sources.
 First, we need to know ID of Connection Method, which is of variant DM_v1.0.0. To do so, perform HTTP `GET`
 on the following URI `https://{device-manager_host}:{port}/redfish/v1/AggregationService/ConnectionMethods`, 
-providing `{user}:{password}` (default username is `admin` and default password is `D3v1ceMgr`).
+providing `{user}:{password}` (your chosen username and password).
 Check each record, to find the proper Connection Method.
 
 ```shell
@@ -96,7 +99,7 @@ curl --location -X POST -k -u '{user}:{password}' 'https://127.0.0.1:45000/redfi
 --data-raw '{
 "HostName": "device-manager:45003",
 "UserName": "admin",
-"Password": "D3v1ceMgr",
+"Password": "your_password",
 "Links": {
 "ConnectionMethod": {
 "@odata.id": "/redfish/v1/AggregationService/ConnectionMethods/3326bd25-c230-4083-95d7-a51b7af5bec3"

--- a/build/redis/createSchema.sh
+++ b/build/redis/createSchema.sh
@@ -1,7 +1,7 @@
 redis-cli -p 6380 <<HERE
 Set  "registry:assignedprivileges"  '{"List":["Login", "ConfigureManager", "ConfigureUsers", "ConfigureSelf", "ConfigureComponents"]}'
 Set "roles:redfishdefined"  '{"List":["Administrator", "Operator", "ReadOnly"]}'
-Set "User:admin"  '{"UserName":"admin","Password":"YmzjkpHW8NIKoLJ6Lp5bufhl6bosH8U7Gy7rLeo8t8ixFk5soWalYa4FX8m8cjnfI6AKtoxTo7DfGdphNk3Y8g==","RoleId":"Administrator", "AccountTypes":["Redfish"]}'
+Set "User:admin"  '{"UserName":"admin","Password":"your_password_here","RoleId":"Administrator", "AccountTypes":["Redfish"]}'
 Set "role:Administrator"  '{"@odata.type":"","RoleId":"Administrator","Name":"","Description":"","IsPredefined":true,"AssignedPrivileges":["ConfigureSelf","Login","ConfigureUsers","ConfigureComponents","ConfigureManager"],"OemPrivileges":null,"@odata.context":"","@odata.id":""}'
 Set "role:Operator"  '{"@odata.type":"","RoleId":"Operator","Name":"","Description":"","IsPredefined":true,"AssignedPrivileges":["ConfigureSelf","Login","ConfigureComponents"],"OemPrivileges":null,"@odata.context":"","@odata.id":""}'
 Set "role:ReadOnly"  '{"@odata.type":"","RoleId":"ReadOnly","Name":"","Description":"","IsPredefined":true,"AssignedPrivileges":["ConfigureSelf","Login"],"OemPrivileges":null,"@odata.context":"","@odata.id":""}'

--- a/svc-device-manager/config/config.yml
+++ b/svc-device-manager/config/config.yml
@@ -15,8 +15,7 @@ TLSConf:
 
 ### Basic Authentication
 UserName: admin
-### Default password: D3v1ceMgr
-Password: YmzjkpHW8NIKoLJ6Lp5bufhl6bosH8U7Gy7rLeo8t8ixFk5soWalYa4FX8m8cjnfI6AKtoxTo7DfGdphNk3Y8g==
+Password: #insert_your_password_here
 
 ### Redfish service root UUID for Device Manager
 RootServiceUUID: 99999999-9999-9999-9999-999999999999


### PR DESCRIPTION
Users should provide their own passwords for projects - many people leave default ones in place, without changing them. These changes force users to set their own passwords before running the project.